### PR TITLE
Specify own compilation flags in addition to one specified by environmen...

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -24,8 +24,8 @@
 SRCS=$(wildcard src/*.c)
 OBJS=$(SRCS:src/%.c=obj/%.o)
 
-CCFLAGS ?= -std=c99 -O3 -fPIC -Wall -Iinclude/ -I.
-LDFLAGS ?= -shared -fPIC
+CCFLAGS += -std=c99 -O3 -fPIC -Wall -Iinclude/ -I.
+LDFLAGS += -shared -fPIC
 
 EXECUTABLE = libcintelhex.so
 STATICLIB  = libcintelhex.a


### PR DESCRIPTION
...t

Different build package systems (on Gentoo or Arch) tend to specify a few
default compile/link flags. Makefile should add its own flags to the list.

Signed-off-by: Anatol Pomozov anatol.pomozov@gmail.com
