### PR TITLE
Add new API function ihex_byte_copy().

### DIFF
--- a/include/cintelhex.h
+++ b/include/cintelhex.h
@@ -164,7 +164,9 @@ int ihex_check_record(ihex_record_t *r);
 
 /// Copy the content of a record set.
 /** This method copies the content of a record set to a certain
- *  location in memory.
+ *  location in memory.  The destination memory is completely zeroed
+ *  before copying the record set content.  Record addresses outside
+ *  the given destination range lead to an error.
  * 
  *  @param rs  The record set that is to be copied.
  *  @param dst A pointer to the destination address.
@@ -173,6 +175,19 @@ int ihex_check_record(ihex_record_t *r);
  *  @param o   Defines whether data words are big or little endian.
  *  @return    0 on success, an error code otherwise. */
 int ihex_mem_copy(ihex_recordset_t *rs, void* dst, ulong_t n, ihex_width_t w, ihex_byteorder_t o);
+
+/// Copy the content of a record set byte-wise.
+/** This method copies the content of a record set to a certain
+ *  location in memory.  In contrast to ihex_mem_copy(), the
+ *  destination memory is not zeroed first.  Any record contents whose
+ *  address lies outside the given destination range are silently
+ *  skipped.
+ * 
+ *  @param rs  The record set that is to be copied.
+ *  @param dst A pointer to the destination address.
+ *  @param n   The size of the allocated target area.
+ *  @return    0 on success, an error code otherwise. */
+int ihex_byte_copy(ihex_recordset_t *rs, char *dst, size_t n);
 
 /// Fill a memory area with zeroes.
 /** This method fills a whole memory area with zeros.


### PR DESCRIPTION
This new implementation avoids the issues #12 and #14 by copying byte-wise. Therefore, no endian conversion is necessary.

An important detail is the difference to ihex_mem_copy() regarding the initialization of destination memory. This new function **does NOT zero** the destination memory prior to copying. In some applications (such as mine) this may be more desireable. If necessary, the user can still call ihex_mem_zero() in advance.

Record contents whose address lies beyond the given destination range are silently discarded instead of aborting with an IHEX_ERR_ADDRESS_OUT_OF_RANGE error code, which makes partial extraction of the ihex record data possible.

As usual, one could come up with a better function name, but I think this is rather descriptive and allows later adding ihex_word_copy() etc.
