### PR TITLE
More powerful version of ihex_byte_copy()

### DIFF
--- a/include/cintelhex.h
+++ b/include/cintelhex.h
@@ -213,7 +213,9 @@ int ihex_check_record(ihex_record_t *r);
 
 /// Copy the content of a record set.
 /** This method copies the content of a record set to a certain
- *  location in memory.
+ *  location in memory.  The destination memory is completely zeroed
+ *  before copying the record set content.  Record addresses outside
+ *  the given destination range lead to an error.
  * 
  *  @param rs  The record set that is to be copied.
  *  @param dst A pointer to the destination address.
@@ -222,6 +224,21 @@ int ihex_check_record(ihex_record_t *r);
  *  @param o   Defines whether data words are big or little endian.
  *  @return    0 on success, an error code otherwise. */
 int ihex_mem_copy(ihex_recordset_t *rs, void* dst, ulong_t n, ihex_width_t w, ihex_byteorder_t o);
+
+/// Copy the content of a record set byte-wise.
+/** This method copies the content of a record set to a certain
+ *  location in memory.  In contrast to ihex_mem_copy(), the
+ *  destination memory is not zeroed first.  Any record contents whose
+ *  address lies outside the given destination range are silently
+ *  skipped.  An offset causes the copy to start at the specified
+ *  address within the source data.
+ * 
+ *  @param rs  The record set that is to be copied.
+ *  @param dst A pointer to the destination address.
+ *  @param n   The size of the allocated target area.
+ *  @param off Offset address from where to start the copy.
+ *  @return    0 on success, an error code otherwise. */
+int ihex_byte_copy(ihex_recordset_t *rs, char *dst, size_t n, size_t off);
 
 /// Fill a memory area with zeroes.
 /** This method fills a whole memory area with zeros.

--- a/src/ihex_copy.c
+++ b/src/ihex_copy.c
@@ -96,6 +96,52 @@ int ihex_mem_copy(ihex_recordset_t *rs, void* dst, ulong_t n,
 	return 0;
 }
 
+int ihex_byte_copy(ihex_recordset_t *rs, char *dst, size_t n, size_t off)
+{
+	int r;
+	uint_t   i = 0, j;
+	uint32_t offset = 0x00, address = 0x00, min = UINT32_MAX, max = 0;
+	
+	ihex_record_t *x;
+	
+	do {
+		r = ihex_rs_iterate_data(rs, &i, &x, &offset);
+		if (r) return r;
+		
+		address = (offset + x->ihr_address);
+		if (address < min) min = address;
+		
+		if (x == 0) {
+			if (off + n < min || off >= max)
+			{
+				IHEX_SET_ERROR_RETURN(IHEX_ERR_ADDRESS_OUT_OF_RANGE,
+					"No data in range 0x%08zx to 0x%08zx",
+					off, off + n);
+			}
+			break;
+		}
+		
+		if (address + x->ihr_length > max) max = address + x->ihr_length;
+		// Skip record if its last address lies before the target range
+		if (address + x->ihr_length < off) break;
+		// Skip bytes until start of target range
+		j = (off > address) ? off - address : 0;
+		for (; j < x->ihr_length; j ++)
+		{
+			// Skip the rest of the content beyond target range
+			if (address + j - off >= n) break;
+			dst[address + j - off] = x->ihr_data[j];
+			
+			#ifdef IHEX_DEBUG
+			printf("%08x -> %08x\n", address + j,
+			       dst[address + j - off]);
+			#endif
+		}
+	} while (i > 0);
+	
+	return 0;
+}
+
 int ihex_mem_zero(void* dst, ulong_t n)
 {
 #ifdef HAVE_MEMSET

--- a/src/ihex_copy.c
+++ b/src/ihex_copy.c
@@ -108,9 +108,6 @@ int ihex_byte_copy(ihex_recordset_t *rs, char *dst, size_t n, size_t off)
 		r = ihex_rs_iterate_data(rs, &i, &x, &offset);
 		if (r) return r;
 		
-		address = (offset + x->ihr_address);
-		if (address < min) min = address;
-		
 		if (x == 0) {
 			if (off + n < min || off >= max)
 			{
@@ -121,6 +118,8 @@ int ihex_byte_copy(ihex_recordset_t *rs, char *dst, size_t n, size_t off)
 			break;
 		}
 		
+		address = (offset + x->ihr_address);
+		if (address < min) min = address;
 		if (address + x->ihr_length > max) max = address + x->ihr_length;
 		// Skip record if its last address lies before the target range
 		if (address + x->ihr_length < off) break;


### PR DESCRIPTION
This one is based on and contains the changes of Pull Request #17.

This alternative version is more flexible and allows an offset to be specified, in case the user wants to copy just a part of the data. Setting the new last argument to zero behaves just as the previous implementation. A bit more error checking is added on top of that, to detect when the requested data range was not contained in the record set at all.

This one works well together with Pull Request #18 to find the most sensible values for `off` and `n` parameters.
- No unit tests yet.
- An example in the README.md would probably be nice for grokking this part of the API.
- The code to iterate through records while adjusting offset addresses, checking for premature EOF, etc. should probably be factored out and reused where applicable. I have some ideas there, but it's probably better to discuss the new parts of the API first.
