### PR TITLE
Fix compiler warnings resulting from invalid "errno" variable name

### DIFF
--- a/src/ihex_copy.c
+++ b/src/ihex_copy.c
@@ -29,16 +29,16 @@
 #include <string.h>
 
 
-#define IHEX_SET_ERROR(errno, error, ...) \
+#define IHEX_SET_ERROR(errnum, error, ...) \
 	{ char *e = malloc(512); \
 	  snprintf(e, 512, error, ##__VA_ARGS__); \
-	  ihex_set_error(errno, e);}
-#define IHEX_SET_ERROR_RETURN(errno, error, ...) \
-	{ IHEX_SET_ERROR(errno, error, ##__VA_ARGS__); \
-	  return errno;}
+	  ihex_set_error(errnum, e); }
+#define IHEX_SET_ERROR_RETURN(errnum, error, ...) \
+	{ IHEX_SET_ERROR(errnum, error, ##__VA_ARGS__); \
+	  return errnum; }
 
 
-void ihex_set_error(ihex_error_t errno, char* error);
+void ihex_set_error(ihex_error_t errnum, char* error);
 
 int ihex_mem_copy(ihex_recordset_t *rs, void* dst, ulong_t n,
                   ihex_width_t w, ihex_byteorder_t o)

--- a/src/ihex_parse.c
+++ b/src/ihex_parse.c
@@ -38,15 +38,16 @@
 
 #define IHEX_CHR_RECORDMARK 0x3A
 
-#define IHEX_SET_ERROR(errno, error, ...) \
+#define IHEX_SET_ERROR(errnum, error, ...) \
 	{ char *e = malloc(512); \
 	  snprintf(e, 512, error, ##__VA_ARGS__); \
-	  ihex_set_error(errno, e);}
-#define IHEX_SET_ERROR_RETURN(errno, error, ...) \
-	{ IHEX_SET_ERROR(errno, error, ##__VA_ARGS__); \
-	  return errno; }
+	  ihex_set_error(errnum, e); }
+#define IHEX_SET_ERROR_RETURN(errnum, error, ...) \
+	{ IHEX_SET_ERROR(errnum, error, ##__VA_ARGS__); \
+	  return errnum; }
 
-void ihex_set_error(ihex_error_t errno, char* error);
+
+void ihex_set_error(ihex_error_t errnum, char* error);
 
 static int ihex_parse_single_record(ihex_rdata_t data, unsigned int length, ihex_record_t* record);
 
@@ -292,9 +293,9 @@ char* ihex_error()
 	return ihex_last_error;
 }
 
-void ihex_set_error(ihex_error_t errno, char* error)
+void ihex_set_error(ihex_error_t errnum, char* error)
 {
-	ihex_last_errno = errno;
+	ihex_last_errno = errnum;
 	ihex_last_error = error;
 				
 	#ifdef IHEX_DEBUG

--- a/src/ihex_record.c
+++ b/src/ihex_record.c
@@ -27,16 +27,16 @@
 #include <stdio.h>
 
 
-#define IHEX_SET_ERROR(errno, error, ...) \
+#define IHEX_SET_ERROR(errnum, error, ...) \
 	{ char *e = malloc(512); \
 	  snprintf(e, 512, error, ##__VA_ARGS__); \
-	  ihex_set_error(errno, e);}
-#define IHEX_SET_ERROR_RETURN(errno, error, ...) \
-	{ IHEX_SET_ERROR(errno, error, ##__VA_ARGS__); \
-	  return errno;}
+	  ihex_set_error(errnum, e); }
+#define IHEX_SET_ERROR_RETURN(errnum, error, ...) \
+	{ IHEX_SET_ERROR(errnum, error, ##__VA_ARGS__); \
+	  return errnum; }
 
 
-void ihex_set_error(ihex_error_t errno, char* error);
+void ihex_set_error(ihex_error_t errnum, char* error);
 
 ulong_t ihex_rs_get_size(ihex_recordset_t* rs)
 {


### PR DESCRIPTION
This fixes a couple of compiler warnings on MinGW.

The ISO C standard lists `errno` as a reserved word. It should not be used as a variable or parameter name by itself. On some platforms it is actually a macro, not a variable identifier, leading to rather confusing warning messages.
