### PR TITLE
Remove nonsense _POSIX definition from CPPFLAGS.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,7 +18,6 @@
 # <http://www.gnu.org/licenses/>.
 #
 
-AM_CPPFLAGS = -D_POSIX
 AM_CFLAGS = -Wall
 
 lib_LTLIBRARIES = libcintelhex.la


### PR DESCRIPTION
As discussed in issue #25, this should never have been defined.
Fixes #25.
