### PR TITLE
Fix reading past EOF on windows.

### DIFF
--- a/src/ihex_parse.c
+++ b/src/ihex_parse.c
@@ -48,7 +48,7 @@
 
 // Flags for open() syscall
 #ifndef O_BINARY
-#define O_BINARY
+#define O_BINARY 0
 #endif
 
 

--- a/src/ihex_parse.c
+++ b/src/ihex_parse.c
@@ -46,6 +46,11 @@
 	{ IHEX_SET_ERROR(errnum, error, ##__VA_ARGS__); \
 	  return errnum; }
 
+// Flags for open() syscall
+#ifndef O_BINARY
+#define O_BINARY
+#endif
+
 
 void ihex_set_error(ihex_error_t errnum, char* error);
 
@@ -60,7 +65,7 @@ ihex_recordset_t* ihex_rs_from_file(const char* filename)
 	
 	ihex_recordset_t* r;
 	
-	fd = open(filename, O_RDONLY);
+	fd = open(filename, O_RDONLY | O_BINARY);
 	if (fd < 0)
 	{
 		IHEX_SET_ERROR(IHEX_ERR_NO_INPUT, "Input file %s does not exist", filename);


### PR DESCRIPTION
On windows, a file is implicitly opened in text mode unless the
O_BINARY flag is passed to open().  While reading from the file, CRLF
line endings are then automatically converted to just LF newlines.
This causes the number of bytes that can be read from the file to
differ from the file length reported by fstat().

As a consequence, the ihex_rs_from_mem() loop for counting the records
will read from a buffer that contains less bytes than expected
(although properly sized), caused by the missing CR characters.
Subsequently it can lead to a wrong number of records reported in the
rs->ihrs_count field, if the uninitialized garbage in the buffer
happens to contain additional IHEX_CHR_RECORDMARK bytes.

Open file in O_BINARY mode if supported (useful on Windows).