### PR TITLE
Re-enable Clang build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: c
 compiler:
   - gcc
   - clang
-matrix:
-  allow_failures:
-    - compiler: clang
 install: sudo apt-get update && sudo apt-get install libcunit1-dev
 before_script: autoreconf --install
 script: ./configure && make && make check


### PR DESCRIPTION
In the latest Travis builds, all tests passed in the Clang build.

Since this seems relatively stable, the Clang build will not be allowed to fail in the future any more.