### PR TITLE
Add new API functions ihex_wordXX_copy()

### DIFF
--- a/include/cintelhex.h
+++ b/include/cintelhex.h
@@ -213,7 +213,9 @@ int ihex_check_record(ihex_record_t *r);
 
 /// Copy the content of a record set.
 /** This method copies the content of a record set to a certain
- *  location in memory.
+ *  location in memory.  The destination memory is completely zeroed
+ *  before copying the record set content.  Record addresses outside
+ *  the given destination range lead to an error.
  * 
  *  @param rs  The record set that is to be copied.
  *  @param dst A pointer to the destination address.
@@ -222,6 +224,21 @@ int ihex_check_record(ihex_record_t *r);
  *  @param o   Defines whether data words are big or little endian.
  *  @return    0 on success, an error code otherwise. */
 int ihex_mem_copy(ihex_recordset_t *rs, void* dst, ulong_t n, ihex_width_t w, ihex_byteorder_t o);
+
+/// Copy the content of a record set byte-wise.
+/** This method copies the content of a record set to a certain
+ *  location in memory.  In contrast to ihex_mem_copy(), the
+ *  destination memory is not zeroed first.  Any record contents whose
+ *  address lies outside the given destination range are silently
+ *  skipped.  An offset causes the copy to start at the specified
+ *  address within the source data.
+ * 
+ *  @param rs  The record set that is to be copied.
+ *  @param dst A pointer to the destination address.
+ *  @param n   The size of the allocated target area.
+ *  @param off Offset address from where to start the copy.
+ *  @return    0 on success, an error code otherwise. */
+int ihex_byte_copy(ihex_recordset_t *rs, char *dst, size_t n, size_t off);
 
 /// Fill a memory area with zeroes.
 /** This method fills a whole memory area with zeros.

--- a/include/cintelhex.h
+++ b/include/cintelhex.h
@@ -51,6 +51,7 @@ extern "C"
 #define IHEX_ERR_MMAP_FAILED          0x09
 #define IHEX_ERR_READ_FAILED          0x0B
 #define IHEX_ERR_MALLOC_FAILED        0x0A
+#define IHEX_ERR_RECORD_NOT_ALIGNED   0x0B
 
 // TYPE DEFINITIONS
 

--- a/include/cintelhex.h
+++ b/include/cintelhex.h
@@ -225,6 +225,49 @@ int ihex_check_record(ihex_record_t *r);
  *  @return    0 on success, an error code otherwise. */
 int ihex_mem_copy(ihex_recordset_t *rs, void* dst, ulong_t n, ihex_width_t w, ihex_byteorder_t o);
 
+/// Copy the content of a record set word-wise.
+/** This method copies the content of a record set to an array of
+ *  8-bit words in memory.
+ * 
+ *  @param rs  The record set that is to be copied.
+ *  @param dst A pointer to the destination address.
+ *  @param n   The number of elements in the target array.
+ *  @return    0 on success, an error code otherwise. */
+int ihex_word8_copy(ihex_recordset_t *rs, uint8_t *dst, size_t n);
+
+/// Copy the content of a record set word-wise in 16-bit blocks.
+/** This method copies the content of a record set to an array of
+ *  16-bit words in memory.
+ * 
+ *  @param rs  The record set that is to be copied.
+ *  @param dst A pointer to the destination address.
+ *  @param n   The number of elements in the target array.
+ *  @param o   Defines whether data words are big or little endian.
+ *  @return    0 on success, an error code otherwise. */
+int ihex_word16_copy(ihex_recordset_t *rs, uint16_t *dst, size_t n, ihex_byteorder_t o);
+
+/// Copy the content of a record set word-wise in 32-bit blocks.
+/** This method copies the content of a record set to an array of
+ *  32-bit words in memory.
+ * 
+ *  @param rs  The record set that is to be copied.
+ *  @param dst A pointer to the destination address.
+ *  @param n   The number of elements in the target array.
+ *  @param o   Defines whether data words are big or little endian.
+ *  @return    0 on success, an error code otherwise. */
+int ihex_word32_copy(ihex_recordset_t *rs, uint32_t *dst, size_t n, ihex_byteorder_t o);
+
+/// Copy the content of a record set word-wise in 64-bit blocks.
+/** This method copies the content of a record set to an array of
+ *  64-bit words in memory.
+ * 
+ *  @param rs  The record set that is to be copied.
+ *  @param dst A pointer to the destination address.
+ *  @param n   The number of elements in the target array.
+ *  @param o   Defines whether data words are big or little endian.
+ *  @return    0 on success, an error code otherwise. */
+int ihex_word64_copy(ihex_recordset_t *rs, uint64_t *dst, size_t n, ihex_byteorder_t o);
+
 /// Copy the content of a record set byte-wise.
 /** This method copies the content of a record set to a certain
  *  location in memory.  In contrast to ihex_mem_copy(), the

--- a/src/ihex_copy.c
+++ b/src/ihex_copy.c
@@ -142,6 +142,71 @@ int ihex_byte_copy(ihex_recordset_t *rs, char *dst, size_t n, size_t off)
 	return 0;
 }
 
+int ihex_word8_copy(ihex_recordset_t *rs, uint8_t *dst, size_t n)
+{
+	return ihex_byte_copy(rs, (char*) dst, n, 0);
+}
+
+#define ALIGNMENT_CHECK(start, length, align)				\
+	if ((start) % (align) != 0) {					\
+		IHEX_SET_ERROR_RETURN(					\
+			IHEX_ERR_RECORD_NOT_ALIGNED,			\
+			"Record address 0x%08x misaligned for requested data type", \
+			(start));					\
+	} else if ((length) % (align) != 0) {				\
+		IHEX_SET_ERROR_RETURN(					\
+			IHEX_ERR_RECORD_NOT_ALIGNED,			\
+			"Record length 0x%08x does not match requested data type", \
+			(length));					\
+	}
+
+int ihex_word16_copy(ihex_recordset_t *rs, uint16_t *dst, size_t n, ihex_byteorder_t o)
+{
+	uint_t   i = 0;
+	uint32_t offset = 0x00, address;
+	
+	ihex_record_t *x;
+	
+	do {
+		int r = ihex_rs_iterate_data(rs, &i, &x, &offset);
+		if (r) return r;
+		else if (x == 0) break;
+		
+		address = (offset + x->ihr_address);
+		ALIGNMENT_CHECK(address, x->ihr_length, sizeof(*dst))
+		/* if (address % sizeof(*dst) != 0) { */
+		/* 	IHEX_SET_ERROR_RETURN(IHEX_ERR_RECORD_NOT_ALIGNED, */
+		/* 		"Record address 0x%08x misaligned for requested data type", */
+		/* 		address); */
+		/* } else if (x->ihr_length % sizeof(*dst) != 0) { */
+		/* 	IHEX_SET_ERROR_RETURN(IHEX_ERR_RECORD_NOT_ALIGNED, */
+		/* 		"Record length 0x%08x does not match requested data type", */
+		/* 		x->ihr_length); */
+		/* } */
+		
+		for (uint_t j = 0; j < x->ihr_length; j += sizeof(*dst))
+		{
+			size_t element = (address + j) / sizeof(*dst);
+			if (element >= n) break;
+			uint16_t  v      = 0;
+			
+			for (uint_t l = 0; l < sizeof(*dst); ++l)
+			{
+				v += x->ihr_data[j + l] << (8 * ((o == IHEX_ORDER_BIGENDIAN)
+								 ? ((sizeof(*dst) - 1) - l)
+								 : l));
+			}
+			dst[element] = v;
+			
+			#ifdef IHEX_DEBUG
+			printf("%08x -> %08x = %08x\n", address + j, v, dst[element]);
+			#endif
+		}
+	} while (i > 0);
+	
+	return 0;
+}
+
 int ihex_mem_zero(void* dst, ulong_t n)
 {
 #ifdef HAVE_MEMSET

--- a/src/ihex_copy.c
+++ b/src/ihex_copy.c
@@ -96,6 +96,52 @@ int ihex_mem_copy(ihex_recordset_t *rs, void* dst, ulong_t n,
 	return 0;
 }
 
+int ihex_byte_copy(ihex_recordset_t *rs, char *dst, size_t n, size_t off)
+{
+	int r;
+	uint_t   i = 0, j;
+	uint32_t offset = 0x00, address = 0x00, min = UINT32_MAX, max = 0;
+	
+	ihex_record_t *x;
+	
+	do {
+		r = ihex_rs_iterate_data(rs, &i, &x, &offset);
+		if (r) return r;
+		
+		address = (offset + x->ihr_address);
+		if (address < min) min = address;
+		
+		if (x == 0) {
+			if (off + n < min || off >= max)
+			{
+				IHEX_SET_ERROR_RETURN(IHEX_ERR_ADDRESS_OUT_OF_RANGE,
+					"No data in range 0x%08zx to 0x%08zx",
+					off, off + n);
+			}
+			break;
+		}
+		
+		if (address + x->ihr_length > max) max = address + x->ihr_length;
+		// Skip record if its last address lies before the target range
+		if (address + x->ihr_length < off) break;
+		// Skip bytes until start of target range
+		j = (off > address) ? off - address : 0;
+		for (; j < x->ihr_length; j ++)
+		{
+			// Skip the rest of the content beyond target range
+			if (address + j - off >= n) break;
+			dst[address + j - off] = x->ihr_data[j];
+			
+			#ifdef IHEX_DEBUG
+			printf("%08x -> %08x\n", address + j,
+			       dst[address + j - off]);
+			#endif
+		}
+	} while (i > 0);
+	
+	return 0;
+}
+
 int ihex_mem_zero(void* dst, ulong_t n)
 {
 #ifdef HAVE_MEMSET


### PR DESCRIPTION
Rebased version of the previous branch https://github.com/acolomb/libcintelhex/tree/draft-copy-words at 4810fdc8a60a4326b0fb8d88b16558ba00b252e2.

**TODO before merging:**
- Decide on the approach to handle #14
- Implement for all word widths
- Code formatting according to #32
- Add unit tests (I'm still uncertain what / how I should test)
- Bump libtool version for added API
